### PR TITLE
Use windows.h instead of afxres.h

### DIFF
--- a/src/Native/version.rc
+++ b/src/Native/version.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include <windows.h>
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS


### PR DESCRIPTION
This fixes a compile error that came about (I think) I opted not to install MFC
