### PR TITLE
Add keyboard accelerators for Attach commands.

### DIFF
--- a/src/VsChromium/VsChromium.vsct
+++ b/src/VsChromium/VsChromium.vsct
@@ -100,7 +100,7 @@
         <Icon guid="guidPackageChromeDebugImages" id="bmpAttachDescendants" />
         <Strings>
           <CommandName>Chrome Debug: Attach to descendants of current debug session</CommandName>
-          <ButtonText>Attach to Descendents of Currently Debugged Processes</ButtonText>
+          <ButtonText>Attach to Descendants of Currently Debugged Processes</ButtonText>
         </Strings>
       </Button>
     </Buttons>


### PR DESCRIPTION
Keyboard accelerators for Attach commands are
bound to Ctrl+[, Alt+[, and Ctrl+Alt+[. These are
picked for mnemonic harmony with Ctrl+Alt+P.

Use names that start with "Attach" for these
commands in the menus, so that they're easier
to find in the keyboard customization menu.
The names in that menu take the form
Debug.WhateverTheButtonTextIs, so we were
winding up with Debug.Attach
