### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-#VsChromium
+# VsChromium
 
 VsChromium is a Visual Studio Extension containing a collection of tools
 useful for editing, navigating and debugging code.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
